### PR TITLE
Use underscore in ivar name

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -458,19 +458,21 @@ module Minitest
     # Hashes! Arrays! Strings!
 
     def metadata
-      @metadata ||= {}
+      @_metadata ||= {}
     end
 
     ##
     # Sets metadata, mainly used for +Result.from+.
 
-    attr_writer :metadata
+    def metadata=(metadata)
+      @_metadata = metadata
+    end
 
     ##
     # Returns true if metadata exists.
 
     def metadata?
-      defined? @metadata
+      defined? @_metadata
     end
 
     ##


### PR DESCRIPTION
We ran into some unexpected behavior around the new `metadata` property. We were using instance variables named `@metadata` in our setup to store expected data structures. Occasionally these included references to complex objects that can't be serialized with `Marshal.dump`.

See the commit comments for more details: https://github.com/minitest/minitest/commit/de802824b3d04c91195170f2988a6bcc28c01495#commitcomment-123380695 Using `@_metadata` for the instance variable name here should reduce the chance of collisions.